### PR TITLE
Add URLSession to APIComponents

### DIFF
--- a/Sources/Relax/API Structure/APIComponent.swift
+++ b/Sources/Relax/API Structure/APIComponent.swift
@@ -30,6 +30,9 @@ public protocol APIComponent {
     
     /// The configuration to use for any Requests provided by this component or its children
     static var configuration: Request.Configuration { get }
+    
+    /// The URLSession to use for any Requests defined in this component or its children. The default is `URLSession.shared`.
+    static var session: URLSession { get }
 }
 
 //MARK: Default Implementation
@@ -39,9 +42,9 @@ extension APIComponent {
     @Request.Properties.Builder
     public static var sharedProperties: Request.Properties { .empty }
     
-    public static var allProperties: Request.Properties {
-        sharedProperties
-    }
+    public static var allProperties: Request.Properties { sharedProperties }
+    
+    public static var session: URLSession { .shared }
 }
 
 //MARK: - APISubComponent
@@ -58,6 +61,10 @@ extension APISubComponent {
     
     public static var configuration: Request.Configuration {
         Parent.configuration
+    }
+    
+    public static var session: URLSession {
+        Parent.session
     }
 }
 

--- a/Sources/Relax/Relax.docc/Request/DefiningRequests.md
+++ b/Sources/Relax/Relax.docc/Request/DefiningRequests.md
@@ -59,9 +59,9 @@ let request = Request(.post, url: URL(string: "https://example.com/users")!) {
 }
 ```
 
-### Session
+### Request Session
 
-When sending requests, a `URLSession` is used, and can be configured through the ``Request/session`` property. If not
+When sending requests, a `URLSession` is used, which can be configured through the ``Request/session`` property. If not
 specified, this property will inherit from the
 [`parent`](<doc:Request/init(_:parent:configuration:session:properties:)>) if defined, otherwise it will be set to
 `URLSession.shared` by default. See <doc:DefiningAPIStructure> for more on inheritance.
@@ -89,19 +89,32 @@ let request = Request(.get, url: URL(string: "https://example.com/")!)
 // a request using a specific URLSession
 let customSessionRequest = Request(.get, url: URL(string: "https://example.com/")!, session: mySession)
 ```
+### Configuring a Request
 
-### Configuration
+Sometimes you need more control on a request to modify things such as the timeout interval or cache policy. This can
+be done using the ``Request/Configuration-swift.struct`` structure. The following example changes the timeout interval
+to 90 seconds instead of the default 60.
 
-A request uses a ``Request/Configuration-swift.struct`` to configure how the request is sent using `URLSession` (the
-configuration is used to set the properties on the underlying `URLRequest` used in making the request). The
-``Request/configuration-swift.property`` can be defined in the
- [`parent`](<doc:Request/init(_:parent:configuration:session:properties:)>) if set, or it can be defined when creating
-a request. If no configuration is defined, a [``default``](<doc:Request/Configuration-swift.struct/default>) set of
-options is used.
+```swift
+let request = Request(
+        .post, 
+        url: URL(string: "https://example.com/users")!,
+        configuration: Request.Configuration(timeout: 90)
+    ) {
+    Body {
+        // Assume that User is an Encodable type
+        User(name: "firstname")
+    }
+}
+```
+
+If no configuration is specified, then the configuration will be inherited from the requests parent ``APIComponent``.
+If the request is standalone (not linked to a parent), then a
+ [`default`](<doc:Request/Configuration-swift.struct/default>) configuration will be used.
 
 See <doc:DefiningAPIStructure> for more on inheritance.
 
-### Modifying Requests
+### Modifying a Request
 
 While many properties can be pre-defined on requests, there may be cases where values need to be changed after
 the request is defined, but before it is sent. In this case, there are modifier style methods available for
@@ -128,25 +141,6 @@ try await request
 ```
 
 For more information on modifying requests, see ``Request``.
-
-### Configuring Requests
-
-Sometimes you need more control on a request to modify things such as the timeout interval or cache policy. This can
-be done using the ``Request/Configuration-swift.struct`` structure. The following example changes the timeout interval
-to 90 seconds instead of the default 60.
-
-```swift
-let request = Request(
-        .post, 
-        url: URL(string: "https://example.com/users")!,
-        configuration: Request.Configuration(timeout: 90)
-    ) {
-    Body {
-        // Assume that User is an Encodable type
-        User(name: "firstname")
-    }
-}
-```
 
 ## Requests in a Complex Structure
 

--- a/Sources/Relax/Relax.docc/Request/DefiningRequests.md
+++ b/Sources/Relax/Relax.docc/Request/DefiningRequests.md
@@ -59,6 +59,48 @@ let request = Request(.post, url: URL(string: "https://example.com/users")!) {
 }
 ```
 
+### Session
+
+When sending requests, a `URLSession` is used, and can be configured through the ``Request/session`` property. If not
+specified, this property will inherit from the
+[`parent`](<doc:Request/init(_:parent:configuration:session:properties:)>) if defined, otherwise it will be set to
+`URLSession.shared` by default. See <doc:DefiningAPIStructure> for more on inheritance.
+
+```swift
+enum MyService: Service {
+     static let baseURL = URL(string: "https://example.com/")!
+     static let session: URLSession = mySession // use a specific URLSession already defined
+
+     // request will use session defined in MyService, mySession
+     static let get = Request(.get, parent: MyService.self)
+
+     // request will use URLSession.shared, overriding the parent session
+     static let getSharedSession = Request(.get, parent: MyService.self, session: .shared)
+ }
+ ```
+
+If a request does not have a parent set, then the session will default to `URLSession.shared`, if not otherwise
+specified.
+
+```swift
+// a request using URLSession.shared
+let request = Request(.get, url: URL(string: "https://example.com/")!)
+
+// a request using a specific URLSession
+let customSessionRequest = Request(.get, url: URL(string: "https://example.com/")!, session: mySession)
+```
+
+### Configuration
+
+A request uses a ``Request/Configuration-swift.struct`` to configure how the request is sent using `URLSession` (the
+configuration is used to set the properties on the underlying `URLRequest` used in making the request). The
+``Request/configuration-swift.property`` can be defined in the
+ [`parent`](<doc:Request/init(_:parent:configuration:session:properties:)>) if set, or it can be defined when creating
+a request. If no configuration is defined, a [``default``](<doc:Request/Configuration-swift.struct/default>) set of
+options is used.
+
+See <doc:DefiningAPIStructure> for more on inheritance.
+
 ### Modifying Requests
 
 While many properties can be pre-defined on requests, there may be cases where values need to be changed after

--- a/Sources/Relax/Relax.docc/Request/Request.md
+++ b/Sources/Relax/Relax.docc/Request/Request.md
@@ -5,8 +5,8 @@
 ### Creating a Request
 
 - <doc:DefiningRequests>
-- ``init(_:url:configuration:properties:)``
-- ``init(_:parent:configuration:properties:)``
+- ``init(_:url:configuration:session:properties:)``
+- ``init(_:parent:configuration:session:properties:)``
 - ``HTTPMethod-swift.struct``
 - ``Configuration-swift.struct``
 - ``RequestBuilder``
@@ -17,6 +17,7 @@
 - ``url``
 - ``urlRequest``
 - ``configuration-swift.property``
+- ``session``
 - ``headers``
 - ``queryItems``
 - ``pathComponents``
@@ -43,15 +44,16 @@
 ### Sending Requests Asynchronously
 
 - <doc:SendingRequestsAsync>
-- ``send(session:)-43n5v``
-- ``send(decoder:session:)-3h323``
+- ``send(session:)-74uav``
+- ``send(decoder:session:)-2kid8``
 - ``AsyncResponse``
 
 ### Sending Requests with a Publisher
 
 - <doc:SendingRequestsPublisher>
-- ``send(session:)-488d1``
-- ``send(decoder:session:)-6f0kg``
+
+- ``send(session:)-8vwky``
+- ``send(decoder:session:)-9jzsp``
 - ``PublisherResponse``
 - ``PublisherModelResponse``
 

--- a/Sources/Relax/Relax.docc/Request/SendingRequests/SendingRequestsAsync.md
+++ b/Sources/Relax/Relax.docc/Request/SendingRequests/SendingRequestsAsync.md
@@ -30,6 +30,32 @@ Task {
 }
 ```
 
+### Overriding the Request Session
+
+Requests are sent using a `URLSession`, which is customizable through the ``Request/session`` property. If
+the request is linked to a `parent` ``APIComponent``, then the session will inherit from the ``APIComponent/session`` by
+default. This can be overridden when a request is sent by passing in a specific `URLSession`:
+
+```swift
+// Uses the session and configuration defined on MyService by default
+let response = try await MyService.get.send()
+
+// Uses a custom URLSession & Configuration for this send only
+let response = try await MyService.get.send(session: customSession)
+```
+
+For detached requests (with no parent), `URLSession.shared` is used by default if no other session is specified:
+
+```swift
+// Uses URLSession.shared
+let response = try await Request(.get, url: URL(string: "https://example.com/")!)
+
+// Uses a specific URLSession
+let response = try await Request(.get, url: URL(string: "https://example.com/")!, session: customSession)
+```
+
+See <doc:DefiningAPIStructure> for more on inheritance.
+
 ### Decoding JSON
 
 You can automatically decode JSON into an expected `Decodable` instance using the

--- a/Sources/Relax/Relax.docc/Request/SendingRequests/SendingRequestsAsync.md
+++ b/Sources/Relax/Relax.docc/Request/SendingRequests/SendingRequestsAsync.md
@@ -4,8 +4,8 @@ Send a Request asynchronously with Swift concurrency.
 
 ## Overview
 
-You can send a ``Request`` which will [`await`](https://docs.swift.org/swift-book/LanguageGuide/Concurrency.html) completion
-in concurrent code. Errors are thrown from the method, which you catch in a `do/catch` block.
+You can send a ``Request`` which will [`await`](https://docs.swift.org/swift-book/LanguageGuide/Concurrency.html)
+completion in concurrent code. Errors are thrown from the method, which you catch in a `do/catch` block.
 
 ## Sending a Request
 
@@ -15,7 +15,7 @@ You can optionally provide your own `URLSession` to use, otherwise `URLSession.s
 
 ### Sending the Request
 
-Use ``Request/send(session:)-43n5v`` to receive `Data` from a request.
+Use ``Request/send(session:)-74uav`` to receive `Data` from a request.
 
 ```swift
 Task {
@@ -32,7 +32,8 @@ Task {
 
 ### Decoding JSON
 
-You can automatically decode JSON into an expected `Decodable` instance using the ``Request/send(decoder:session:)-3h323`` method.
+You can automatically decode JSON into an expected `Decodable` instance using the
+``Request/send(decoder:session:)-2kid8`` method.
 
 > Tip: By default, `JSONDecoder()` is used, but you
 can also pass in your own to the `decoder` parameter.
@@ -52,4 +53,8 @@ Task {
 
 ### Handling Errors
 
-When a failure occurs, ``RequestError`` is thrown. By default, HTTP status codes (`4XX`, `5XX`, etc) returned from the server are not parsed for errors. As a convenience, you can set the ``Request/Configuration-swift.struct/parseHTTPStatusErrors`` parameter in ``Request/Configuration-swift.struct`` to `true` in order to enable this. If enabled, then any HTTP status code outside the `1XX`-`3XX` range will be treated as an error.
+When a failure occurs, ``RequestError`` is thrown. By default, HTTP status codes (`4XX`, `5XX`, etc) returned from the
+server are not parsed for errors. As a convenience, you can set the
+``Request/Configuration-swift.struct/parseHTTPStatusErrors`` parameter in ``Request/Configuration-swift.struct`` to
+`true` in order to enable this. If enabled, then any HTTP status code outside the `1XX`-`3XX` range will be treated as
+an error.

--- a/Sources/Relax/Relax.docc/Request/SendingRequests/SendingRequestsHandler.md
+++ b/Sources/Relax/Relax.docc/Request/SendingRequests/SendingRequestsHandler.md
@@ -4,7 +4,8 @@ Send a request calling a handler upon completion.
 
 ## Overview
 
-You can send a ``Request`` which calls a completion handler closure when a response is received. A `URLSessionDataTask` is returned, which `resume()` will automatically be called by default.
+You can send a ``Request`` which calls a completion handler closure when a response is received. A `URLSessionDataTask`
+is returned, which `resume()` will automatically be called by default.
 
 ## Sending a Request
 
@@ -15,9 +16,12 @@ You can optionally provide your own `URLSession` to use, otherwise `URLSession.s
 ### Sending the Request
 
 Use ``Request/send(session:autoResumeTask:completion:)`` to send the
-request to the server. When a response (or error) is received, the completion handler ``Request/Completion`` will be called with the received data.
+request to the server. When a response (or error) is received, the completion handler ``Request/Completion`` will be
+called with the received data.
 
-> Warning: This method returns a `URLSessionDataTask`, which `resume()` is already called by default. If you call `resume()` on the task again, then the request will be sent a second time, unless the `autoResumeTask` parameter is set to `false`.
+> Warning: This method returns a `URLSessionDataTask`, in which `resume()` is already called by default. If you call
+`resume()` on the task again, then the request will be sent a second time, unless the `autoResumeTask` parameter is set
+to `false`.
 
 ```swift
 let request = Request(.get, url: URL(string: "https://example.com")!)
@@ -32,9 +36,47 @@ request.send { result in
 }
 ```
 
+### Overriding the Request Session
+
+Requests are sent using a `URLSession`, which is customizable through the ``Request/session`` property. If
+the request is linked to a `parent` ``APIComponent``, then the session will inherit from the ``APIComponent/session`` by
+default. This can be overridden when a request is sent by passing in a specific `URLSession`:
+
+```swift
+// Uses the session and configuration defined on MyService by default
+MyService.get.send { result in
+    ...
+}
+
+// Uses a custom URLSession & Configuration for this send only
+MyService.get.send(session: customSession) { result in
+    ...
+}
+```
+
+For detached requests (with no parent), `URLSession.shared` is used by default if no other session is specified:
+
+```swift
+// Uses URLSession.shared
+let request = Request(.get, url: URL(string: "https://example.com")!)
+request.send { result in
+    ...
+}
+
+// Uses a specific URLSession
+let request = Request(.get, url: URL(string: "https://example.com")!)
+request.send(session: customSession) { result in
+    ...
+}
+```
+
+See <doc:DefiningAPIStructure> for more on inheritance.
+
 ### Decoding JSON
 
-You can automatically decode received data into a `Decodable` instance with the ``Request/send(decoder:session:completion:)`` method. This method also uses a completion handler, but instead of `Data`, returns the data decoded to a `Decodable` type.
+You can automatically decode received data into a `Decodable` instance with the
+``Request/send(decoder:session:completion:)`` method. This method also uses a completion handler, but instead of `Data`,
+returns the data decoded to a `Decodable` type.
 
 > Tip: By default, `JSONDecoder()` is used, but you can also pass in your own to the `decoder` parameter.
 
@@ -52,4 +94,8 @@ request.send { (result: Result<User, RequestError> in
 
 ### Handling Errors
 
-When a failure occurs, ``RequestError`` is the failure type of the result returned in the completion handler. By default, HTTP status codes (`4XX`, `5XX`, etc) returned from the server are not parsed for errors. As a convenience, you can set the ``Request/Configuration-swift.struct/parseHTTPStatusErrors`` parameter in ``Request/Configuration-swift.struct`` to `true` in order to enable this. If enabled, then any HTTP status code outside the `1XX`-`3XX` range will be treated as an error.
+When a failure occurs, ``RequestError`` is the failure type of the result returned in the completion handler. By
+default, HTTP status codes (`4XX`, `5XX`, etc) returned from the server are not parsed for errors. As a convenience, you
+can set the ``Request/Configuration-swift.struct/parseHTTPStatusErrors`` parameter in
+``Request/Configuration-swift.struct`` to `true` in order to enable this. If enabled, then any HTTP status code outside
+the `1XX`-`3XX` range will be treated as an error.

--- a/Sources/Relax/Relax.docc/Request/SendingRequests/SendingRequestsPublisher.md
+++ b/Sources/Relax/Relax.docc/Request/SendingRequests/SendingRequestsPublisher.md
@@ -4,8 +4,8 @@ Send a Request using a Combine publisher
 
 ## Overview
 
-You can send a ``Request`` which will return a [Combine publisher](https://developer.apple.com/documentation/combine) which
-publishes data when the request is completed.
+You can send a ``Request`` which will return a [Combine publisher](https://developer.apple.com/documentation/combine)
+which publishes data when the request is completed.
 
 ## Sending a Request
 
@@ -15,7 +15,7 @@ You can optionally provide your own `URLSession` to use, otherwise `URLSession.s
 
 ### Sending the Request
 
-Use ``Request/send(session:)-488d1`` to return a publisher which
+Use ``Request/send(session:)-8vwky`` to return a publisher which
 upon receiving a response from the server, will publish a ``Request/PublisherResponse``.
 
 ```swift
@@ -38,9 +38,8 @@ do {
 
 ### Decoding JSON
 
-You can automatically decode received data into a `Decodable` instance with the
-``Request/send(decoder:session:)-6f0kg``, which will publish a
-``Request/PublisherModelResponse`` with the decoded data.
+You can automatically decode received data into a `Decodable` instance with the``Request/send(decoder:session:)-9jzsp``,
+which will publish a ``Request/PublisherModelResponse`` with the decoded data.
 
 > Tip: By default, `JSONDecoder()` is used, but you can also pass in your own to the `decoder` parameter.
 
@@ -63,4 +62,8 @@ do {
 
 ### Handling Errors
 
-When a failure occurs, ``RequestError`` is the `Failure` of the publisher returned. By default, HTTP status codes (`4XX`, `5XX`, etc) returned from the server are not parsed for errors. As a convenience, you can set the ``Request/Configuration-swift.struct/parseHTTPStatusErrors`` parameter in ``Request/Configuration-swift.struct`` to `true` in order to enable this. If enabled, then any HTTP status code outside the `1XX`-`3XX` range will be treated as an error.
+When a failure occurs, ``RequestError`` is the `Failure` of the publisher returned. By default, HTTP status codes
+(`4XX`, `5XX`, etc) returned from the server are not parsed for errors. As a convenience, you can set the
+``Request/Configuration-swift.struct/parseHTTPStatusErrors`` parameter in ``Request/Configuration-swift.struct`` to
+`true` in order to enable this. If enabled, then any HTTP status code outside the `1XX`-`3XX` range will be treated as
+an error.

--- a/Sources/Relax/Request/Properties/Body.swift
+++ b/Sources/Relax/Request/Properties/Body.swift
@@ -23,13 +23,6 @@ public struct Body: RequestProperty {
         self.init(value: try? encoder.encode(value))
     }
     
-    /// Creates a body from a dictionary
-    /// - Parameter dictionary: Dictionary to serialize as JSON
-    /// - Parameter options: Options for JSONSerialization
-    public init(_ dictionary: [String: Any], options: JSONSerialization.WritingOptions = []) {
-        self.init(value: try? JSONSerialization.data(withJSONObject: dictionary, options: options))
-    }
-    
     /// Creates a body from any number of `Data` or `Encodable` instances using a ``Builder``.
     ///
     /// This initializer combines all `Data` or `Encodable` instances specified in `content`. Each instance will be appended to each other (from top to
@@ -104,10 +97,6 @@ extension Body {
         }
         
         public static func buildExpression<T: Encodable>(_ expression: T) -> Body {
-            .init(expression)
-        }
-        
-        public static func buildExpression(_ expression: [String: Any]) -> Body {
             .init(expression)
         }
     }

--- a/Sources/Relax/Request/Request+Send.swift
+++ b/Sources/Relax/Request/Request+Send.swift
@@ -35,7 +35,7 @@ extension Request {
     
     /// Send a request with a completion handler, returning a data task
     /// - Parameters:
-    ///   - session: The session to use to send the request. Default is `URLSession.shared`.
+    ///   - session: When provided, overrides the session defined in the Request.
     ///   - autoResumeTask: Whether to call `resume()` on the created task. The default is `true`.
     ///   - completion: A completion handler with the response from the server.
     /// - Returns: The task used to make the request
@@ -43,11 +43,11 @@ extension Request {
     /// will result in the request being sent again.
     @discardableResult
     public func send(
-        session: URLSession = .shared,
+        session: URLSession? = nil,
         autoResumeTask: Bool = true,
         completion: @escaping Request.Completion
     ) -> URLSessionDataTask {
-        let task = session.dataTask(with: urlRequest) { data, response, error in
+        let task = (session ?? self.session).dataTask(with: urlRequest) { data, response, error in
             guard error == nil,
                   let data = data else {
                 // Check for URLErrors
@@ -87,12 +87,12 @@ extension Request {
     /// Send a request with a completion handler, decoding the received data to a Decodable instance
     /// - Parameters:
     ///   - decoder: The decoder to decode received data with. Default is `JSONDecoder()`.
-    ///   - session: The session to use to send the request. Default is `URLSession.shared`.
+    ///   - session: When provided, overrides the session defined in the Request.
     ///   - parseHTTPStatusErrors: Whether to parse HTTP status codes returned for errors. The default is `false`.
     ///   - completion: A completion handler with the response from the server, including the decoded data as the Decodable type.
     public func send<ResponseModel: Decodable>(
         decoder: JSONDecoder = JSONDecoder(),
-        session: URLSession = .shared,
+        session: URLSession? = nil,
         completion: @escaping Request.ModelCompletion<ResponseModel>
     ) {
         send(

--- a/Sources/Relax/Request/Request+Send.swift
+++ b/Sources/Relax/Request/Request+Send.swift
@@ -35,7 +35,7 @@ extension Request {
     
     /// Send a request with a completion handler, returning a data task
     /// - Parameters:
-    ///   - session: When provided, overrides the session defined in the Request.
+    ///   - session: When provided, overrides the ``Request/session`` defined in the Request.
     ///   - autoResumeTask: Whether to call `resume()` on the created task. The default is `true`.
     ///   - completion: A completion handler with the response from the server.
     /// - Returns: The task used to make the request
@@ -87,7 +87,7 @@ extension Request {
     /// Send a request with a completion handler, decoding the received data to a Decodable instance
     /// - Parameters:
     ///   - decoder: The decoder to decode received data with. Default is `JSONDecoder()`.
-    ///   - session: When provided, overrides the session defined in the Request.
+    ///   - session: When provided, overrides the ``Request/session`` defined in the Request.
     ///   - parseHTTPStatusErrors: Whether to parse HTTP status codes returned for errors. The default is `false`.
     ///   - completion: A completion handler with the response from the server, including the decoded data as the Decodable type.
     public func send<ResponseModel: Decodable>(

--- a/Sources/Relax/Request/Request+SendAsync.swift
+++ b/Sources/Relax/Request/Request+SendAsync.swift
@@ -23,7 +23,7 @@ extension Request {
     /// Send a request asynchronously
     ///
     /// - Parameters:
-    ///   - session: When provided, overrides the session defined in the Request.
+    ///   - session: When provided, overrides the ``Request/session`` defined in the Request.
     /// - Returns: A response containing the request sent, url response, and data.
     /// - Throws: A `RequestError` on error.
     @discardableResult
@@ -57,7 +57,7 @@ extension Request {
     /// Send a request asynchronously, decoding data received to a Decodable instance.
     /// - Parameters:
     ///   - decoder: The decoder to decode received data with. Default is `JSONDecoder()`.
-    ///   - session: When provided, overrides the session defined in the Request.
+    ///   - session: When provided, overrides the ``Request/session`` defined in the Request.
     /// - Returns: The model, decoded from received data.
     /// - Throws: A `RequestError` on error.
     public func send<ResponseModel: Decodable>(

--- a/Sources/Relax/Request/Request+SendAsync.swift
+++ b/Sources/Relax/Request/Request+SendAsync.swift
@@ -23,12 +23,12 @@ extension Request {
     /// Send a request asynchronously
     ///
     /// - Parameters:
-    ///   - session: The session to use (default is `URLSession.shared`
+    ///   - session: When provided, overrides the session defined in the Request.
     /// - Returns: A response containing the request sent, url response, and data.
     /// - Throws: A `RequestError` on error.
     @discardableResult
     public func send(
-        session: URLSession = .shared
+        session: URLSession? = nil
     ) async throws -> AsyncResponse {
         var task: URLSessionDataTask?
         let onCancel = { task?.cancel() }
@@ -57,12 +57,12 @@ extension Request {
     /// Send a request asynchronously, decoding data received to a Decodable instance.
     /// - Parameters:
     ///   - decoder: The decoder to decode received data with. Default is `JSONDecoder()`.
-    ///   - session: The session to use to send the request. Default is `URLSession.shared`.
+    ///   - session: When provided, overrides the session defined in the Request.
     /// - Returns: The model, decoded from received data.
     /// - Throws: A `RequestError` on error.
     public func send<ResponseModel: Decodable>(
         decoder: JSONDecoder = JSONDecoder(),
-        session: URLSession = .shared
+        session: URLSession? = nil
     ) async throws -> ResponseModel {
         let response: AsyncResponse = try await send(
             session: session

--- a/Sources/Relax/Request/Request+SendPublisher.swift
+++ b/Sources/Relax/Request/Request+SendPublisher.swift
@@ -28,7 +28,7 @@ extension Request {
     
     /// Send a request, returning a Combine publisher
     /// - Parameters:
-    ///   - session: When provided, overrides the session defined in the Request.
+    ///   - session: When provided, overrides the ``Request/session`` defined in the Request.
     /// - Returns: A Publisher which returns the received data, or a ``RequestError`` on failure.
     public func send(
         session: URLSession? = nil
@@ -52,7 +52,7 @@ extension Request {
     /// Send a request and decode received data to a Decodable instance, returning a Combine publisher
     /// - Parameters:
     ///   - decoder: The decoder to decode received data with. Default is `JSONDecoder()`.
-    ///   - session: When provided, overrides the session defined in the Request.
+    ///   - session: When provided, overrides the ``Request/session`` defined in the Request.
     /// - Returns: A Pubisher which returns the received data, or a ``RequestError`` on failure.
     public func send<ResponseModel: Decodable>(
         decoder: JSONDecoder = JSONDecoder(),

--- a/Sources/Relax/Request/Request+SendPublisher.swift
+++ b/Sources/Relax/Request/Request+SendPublisher.swift
@@ -28,10 +28,10 @@ extension Request {
     
     /// Send a request, returning a Combine publisher
     /// - Parameters:
-    ///   - session: The session to use
+    ///   - session: When provided, overrides the session defined in the Request.
     /// - Returns: A Publisher which returns the received data, or a ``RequestError`` on failure.
     public func send(
-        session: URLSession = .shared
+        session: URLSession? = nil
     ) -> AnyPublisher<PublisherResponse, RequestError> {
         Future<PublisherResponse, RequestError> { promise in
             send(
@@ -52,11 +52,11 @@ extension Request {
     /// Send a request and decode received data to a Decodable instance, returning a Combine publisher
     /// - Parameters:
     ///   - decoder: The decoder to decode received data with. Default is `JSONDecoder()`.
-    ///   - session: The session to use to send the request. Default is `URLSession.shared`.
+    ///   - session: When provided, overrides the session defined in the Request.
     /// - Returns: A Pubisher which returns the received data, or a ``RequestError`` on failure.
     public func send<ResponseModel: Decodable>(
         decoder: JSONDecoder = JSONDecoder(),
-        session: URLSession = .shared
+        session: URLSession? = nil
     ) -> AnyPublisher<ResponseModel, RequestError> {
         send(session: session)
             .map(\.data)

--- a/Sources/Relax/Request/Request.swift
+++ b/Sources/Relax/Request/Request.swift
@@ -19,12 +19,12 @@ import FoundationNetworking
 /// let request = Request(.get, url: URL(string: "https://example.com/")!)
 /// ```
 ///
-/// When reuqests are nested as part of an ``APIComponent`` (``Service`` or ``Endpoint``), you specify the `Parent` type to the initializer or
-/// ``RequestBuilder`` result builder. In the following example, both `request1` and `request2` are equivalent:
+/// When reuqests are nested as part of an ``APIComponent`` (``Service`` or ``Endpoint``), you specify the ``APISubComponent/Parent``  type to
+/// the initializer or ``RequestBuilder`` result builder. In the following example, both `request1` and `request2` are equivalent:
 ///
 /// ```swift
 /// enum MyService: Service {
-///     static let baseURL = URL(string: https://example.com/)!
+///     static let baseURL = URL(string: "https://example.com/")!
 ///
 ///     // Uses the baseURL defined on MyService
 ///     @RequestBuilder<MyService>
@@ -45,7 +45,8 @@ import FoundationNetworking
 ///         .settingHeader(name: "name", value: "value")
 ///         .send()
 /// ```
-/// > Tip: For more details, see <doc:DefiningAPIStructure>, <doc:DefiningRequests>, and <doc:SendingRequestsAsync>, <doc:SendingRequestsPublisher>, or <doc:SendingRequestsHandler>.
+/// > Tip: For more details, see <doc:DefiningAPIStructure>, <doc:DefiningRequests>, and <doc:SendingRequestsAsync>,
+/// <doc:SendingRequestsPublisher>, or <doc:SendingRequestsHandler>.
 ///
 public struct Request: Hashable {    
     /// The HTTP method of the request

--- a/Sources/Relax/Request/Request.swift
+++ b/Sources/Relax/Request/Request.swift
@@ -101,9 +101,16 @@ public struct Request: Hashable {
     ///
     /// The default value is ``Configuration-swift.struct/default``.
     ///
-    /// - Note: This value will be inherited by the parent ``APIComponent`` (``Service``/``Endpoint``)
-    /// when provided
+    /// - Note: This value will be inherited by the parent ``APIComponent`` (``Service``/``Endpoint``) when provided.
     public var configuration: Configuration
+    
+    /// The URLSession to use for this request
+    ///
+    /// The default value is `URLSession.default`
+    /// 
+    /// - Note: This value will be inherited by the parent ``APIComponent`` (``Service``/``Endpoint``) when provided. The session can also be
+    /// overridden when sending requests.
+    public var session: URLSession
     
     /// The request URL
     public var url: URL {
@@ -149,15 +156,23 @@ public struct Request: Hashable {
     ///   - httpMethod: The HTTP method to use
     ///   - url: The base URL of the request (this does not include path components and query items which you provide in `properties`).
     ///   - configuration: The configuration for the request. The default is ``Configuration-swift.struct/default``.
+    ///   - session: The session to use for the request. The default is `URLSession.shared`
     ///   - properties: Any additional properties to use in the request, such as the body, headers, query items, or path components. The default value is
     ///   ``Request/Properties/empty`` (no properties).
     public init(
         _ httpMethod: HTTPMethod,
         url: URL,
         configuration: Configuration = .default,
+        session: URLSession = .shared,
         @Request.Properties.Builder properties: () -> Properties = { .empty }
     ) {
-        self.init(httpMethod: httpMethod, url: url, configuration: configuration, properties: properties())
+        self.init(
+            httpMethod: httpMethod,
+            url: url,
+            configuration: configuration,
+            sesssion: session,
+            properties: properties()
+        )
     }
     
     /// Creates a request using a provided HTTP method, using the base URL, configuration, and any shared properties provided by a parent ``APIComponent``
@@ -167,18 +182,21 @@ public struct Request: Hashable {
     ///   - parent: A parent which provides the base URL, ``Configuration-swift.struct``, and
     ///   ``APIComponent/sharedProperties-5764x``.
     ///   - configuration: An optional configuration to override what is provided by the parent.
+    ///   - session: Overrides the session provided by the parent.
     ///   - properties: A ``Request/Properties/Builder`` closure which provides properties to use in this request. Any provided here will be
     ///   appended to any provided by `parent`. The default value is ``Request/Properties/empty`` (no properties).
     public init(
         _ httpMethod: HTTPMethod,
         parent: APIComponent.Type,
         configuration: Configuration? = nil,
+        session: URLSession? = nil,
         @Request.Properties.Builder properties: () -> Properties = { .empty }
     ) {
         self.init(
             httpMethod: httpMethod,
             url: parent.baseURL,
             configuration: configuration ?? parent.configuration,
+            sesssion: session ?? parent.session,
             properties: parent.allProperties + properties()
         )
     }
@@ -187,13 +205,14 @@ public struct Request: Hashable {
         httpMethod: HTTPMethod,
         url: URL,
         configuration: Configuration,
+        sesssion: URLSession,
         properties: Properties
     ) {
         self._url = url
         
         self.httpMethod = httpMethod
         self.configuration = configuration
-        
+        self.session = sesssion
         self._properties = properties
     }
 }

--- a/Sources/Relax/Request/Request.swift
+++ b/Sources/Relax/Request/Request.swift
@@ -100,17 +100,16 @@ public struct Request: Hashable {
     
     /// The configuration of the request
     ///
-    /// The default value is ``Configuration-swift.struct/default``.
-    ///
-    /// - Note: This value will be inherited by the parent ``APIComponent`` (``Service``/``Endpoint``) when provided.
+    /// This value will be inherited from the parent ``APIComponent`` (``Service``/``Endpoint``), if the request is linked to a parent. If there is no parent,
+    /// the default value is ``Request/Configuration-swift.struct/default``.
     public var configuration: Configuration
     
     /// The URLSession to use for this request
     ///
-    /// The default value is `URLSession.default`
-    /// 
-    /// - Note: This value will be inherited by the parent ``APIComponent`` (``Service``/``Endpoint``) when provided. The session can also be
-    /// overridden when sending requests.
+    /// This value will be inherited from the parent ``APIComponent`` (``Service``/``Endpoint``), if the request is linked to a parent. If there is no parent,
+    /// the default value is `URLSession.shared`.
+    ///
+    /// - Tip: The session can also be overridden when sending requests.
     public var session: URLSession
     
     /// The request URL

--- a/Tests/RelaxTests/Request/Properties/BodyTests.swift
+++ b/Tests/RelaxTests/Request/Properties/BodyTests.swift
@@ -125,6 +125,15 @@ final class BodyTests: XCTestCase {
         XCTAssertEqual(body, Body(model))
     }
     
+    func testBuildDictionary() throws {
+        let content = ["name": "value"]
+        @Body.Builder
+        var body: Body {
+            content
+        }
+        XCTAssertEqual(body, Body(content))
+    }
+    
     func testBuildLimitedAvailability() {
         @Body.Builder
         var body: Body {

--- a/Tests/RelaxTests/Request/ServiceTests.swift
+++ b/Tests/RelaxTests/Request/ServiceTests.swift
@@ -6,6 +6,9 @@
 //
 
 import XCTest
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 import URLMock
 @testable import Relax
 
@@ -83,6 +86,7 @@ final class ServiceTests: XCTestCase {
         XCTAssertEqual(override.configuration, expectedConfiguration)
     }
     
+#if swift(>=5.9)
     func testOverrideSession() async throws {
         let expectation = self.expectation(description: "Mock received")
         let expectedSession = URLMock.session(.mock { _ in
@@ -92,7 +96,7 @@ final class ServiceTests: XCTestCase {
         let override = Request(.get, parent: InheritService.User.self, session: expectedSession)
         try await override.send()
         
-        await fulfillment(of: [expectation])
+        await fulfillment(of: [expectation], timeout: 1)
     }
     
     func testOverrideSessionOnSend() async throws {
@@ -102,8 +106,9 @@ final class ServiceTests: XCTestCase {
         })
         try await InheritService.User.get.send(session: expectedSession)
         
-        await fulfillment(of: [expectation])
+        await fulfillment(of: [expectation], timeout: 1)
     }
+#endif
 }
 
 extension URL {

--- a/Tests/RelaxTests/Request/ServiceTests.swift
+++ b/Tests/RelaxTests/Request/ServiceTests.swift
@@ -69,6 +69,7 @@ final class ServiceTests: XCTestCase {
         
         XCTAssertEqual(Testing.allProperties, .empty)
         XCTAssertEqual(Testing.configuration, .default)
+        XCTAssertEqual(Testing.session, .shared)
     }
     
     func testInheritance() {


### PR DESCRIPTION
Adds a URLSession property to APIComponent, which is inherited by all children (and child Requests). A default implementation using .shared is provided.

Additionally, add a session to Request, using the session provided by Parent. The session parameter to send() methods will now override the session defined in the Request, if provided.