### PR TITLE
Make all Header initializers public

### DIFF
--- a/Sources/Relax/Request/Properties/Headers.swift
+++ b/Sources/Relax/Request/Properties/Headers.swift
@@ -27,7 +27,7 @@ public struct Header: CustomStringConvertible {
     /// - Parameters:
     ///   - name: The header name
     ///   - value: The header value
-    internal init(_ name: Header.Name, _ value: String) {
+    public init(_ name: Header.Name, _ value: String) {
         self.init(name.rawValue, value)
     }
     


### PR DESCRIPTION
The Heder initializer taking a Header.Name was marked as `internal`, but should be `public`.