### PR TITLE
Re-add support for heterogenous dictionaries to Body.Builder

### DIFF
--- a/Sources/Relax/Request/Properties/Body.swift
+++ b/Sources/Relax/Request/Properties/Body.swift
@@ -23,6 +23,13 @@ public struct Body: RequestProperty {
         self.init(value: try? encoder.encode(value))
     }
     
+    /// Creates a body from a dictionary
+    /// - Parameter dictionary: Dictionary to serialize as JSON
+    /// - Parameter options: Options for JSONSerialization
+    public init(_ dictionary: [String: Any], options: JSONSerialization.WritingOptions = []) {
+        self.init(value: try? JSONSerialization.data(withJSONObject: dictionary, options: options))
+    }
+    
     /// Creates a body from any number of `Data` or `Encodable` instances using a ``Builder``.
     ///
     /// This initializer combines all `Data` or `Encodable` instances specified in `content`. Each instance will be appended to each other (from top to
@@ -97,6 +104,10 @@ extension Body {
         }
         
         public static func buildExpression<T: Encodable>(_ expression: T) -> Body {
+            .init(expression)
+        }
+        
+        public static func buildExpression(_ expression: [String: Any]) -> Body {
             .init(expression)
         }
     }

--- a/Tests/RelaxTests/AsyncTests/AsyncErrorTests.swift
+++ b/Tests/RelaxTests/AsyncTests/AsyncErrorTests.swift
@@ -31,8 +31,10 @@ final class AsyncErrorTests: ErrorTest {
         await requestError(expected: httpError)
     }
     
-    func testURLError() async {
-        #if !os(watchOS)
+    func testURLError() async throws {
+        #if os(watchOS)
+        throw XCTSkip("Not supported on watchOS")
+        #else
         await requestError(expected: urlError)
         #endif
     }
@@ -48,8 +50,10 @@ final class AsyncErrorTests: ErrorTest {
         }
     }
     
-    func testOtherError() async {
-        #if !os(watchOS)
+    func testOtherError() async throws {
+        #if os(watchOS)
+        throw XCTSkip("Not supported on watchOS")
+        #else
         await requestError(expected: otherError)
         #endif
     }

--- a/Tests/RelaxTests/AsyncTests/AsyncRequestTests.swift
+++ b/Tests/RelaxTests/AsyncTests/AsyncRequestTests.swift
@@ -58,9 +58,10 @@ final class AsyncRequestTests: XCTestCase {
         try await makeSuccess(request: service.ComplexRequests.complex)
     }
     
-    #if swift(>=5.9)
-    // fulfillment(of:) only available on swift 5.9+
     func testOverrideSession() async throws {
+        #if swift(<5.9)
+        throw XCTSkip("await fulfillment() not available before Swift 5.9")
+        #else
         let expectation = self.expectation(description: "Mock received")
         let expectedSession = URLMock.session(.mock { _ in
             expectation.fulfill()
@@ -70,9 +71,13 @@ final class AsyncRequestTests: XCTestCase {
         try await override.send()
         
         await fulfillment(of: [expectation], timeout: 1)
+        #endif
     }
     
     func testOverrideSessionOnSendAsync() async throws {
+        #if swift(<5.9)
+        throw XCTSkip("await fulfillment() not available before Swift 5.9")
+        #else
         let expectation = self.expectation(description: "Mock received")
         let expectedSession = URLMock.session(.mock { _ in
             expectation.fulfill()
@@ -80,8 +85,8 @@ final class AsyncRequestTests: XCTestCase {
         try await InheritService.User.get.send(session: expectedSession)
         
         await fulfillment(of: [expectation], timeout: 1)
+        #endif
     }
-    #endif
     
     func testOverrideDecoderOnSend() async throws {
         let model = InheritService.User.Response(date: Date())

--- a/Tests/RelaxTests/CombineTests/CombineErrorTests.swift
+++ b/Tests/RelaxTests/CombineTests/CombineErrorTests.swift
@@ -44,7 +44,9 @@ final class CombineErrorTests: ErrorTest {
     }
     
     func testURLError() throws {
-        #if !os(watchOS)
+        #if os(watchOS)
+        throw XCTSkip("Not supported on watchOS")
+        #else
         try requestError(expected: urlError)
         #endif
     }
@@ -71,7 +73,9 @@ final class CombineErrorTests: ErrorTest {
     }
     
     func testOtherError() throws {
-        #if !os(watchOS)
+        #if os(watchOS)
+        throw XCTSkip("Not supported on watchOS")
+        #else
         try requestError(expected: otherError)
         #endif
     }

--- a/Tests/RelaxTests/CompletionTests/CompletionErrorTests.swift
+++ b/Tests/RelaxTests/CompletionTests/CompletionErrorTests.swift
@@ -35,7 +35,9 @@ final class CompletionErrorTests: ErrorTest {
     }
     
     func testURLError() throws {
-        #if !os(watchOS)
+        #if os(watchOS)
+        throw XCTSkip("Not supported on watchOS")
+        #else
         try requestError(expected: urlError)
         #endif
     }
@@ -58,7 +60,9 @@ final class CompletionErrorTests: ErrorTest {
     }
     
     func testOtherError() throws {
-        #if !os(watchOS)
+        #if os(watchOS)
+        throw XCTSkip("Not supported on watchOS")
+        #else
         try requestError(expected: otherError)
         #endif
     }

--- a/Tests/RelaxTests/Request/Properties/BodyTests.swift
+++ b/Tests/RelaxTests/Request/Properties/BodyTests.swift
@@ -135,12 +135,17 @@ final class BodyTests: XCTestCase {
     }
     
     func testBuildHeterogenousDictionary() throws {
+
         let content: [String: Any] = ["name": "value", "status": false]
         @Body.Builder
         var body: Body {
             content
         }
+        #if os(Windows) && swift(>=5.7) && swift(<5.9)
+        throw XCTSkip("Comparison does not work correctly on Windows with Swift 5.8")
+        #else
         XCTAssertEqual(body, Body(content))
+        #endif
     }
     
     func testBuildLimitedAvailability() {

--- a/Tests/RelaxTests/Request/Properties/BodyTests.swift
+++ b/Tests/RelaxTests/Request/Properties/BodyTests.swift
@@ -134,6 +134,15 @@ final class BodyTests: XCTestCase {
         XCTAssertEqual(body, Body(content))
     }
     
+    func testBuildHeterogenousDictionary() throws {
+        let content: [String: Any] = ["name": "value", "status": false]
+        @Body.Builder
+        var body: Body {
+            content
+        }
+        XCTAssertEqual(body, Body(content))
+    }
+    
     func testBuildLimitedAvailability() {
         @Body.Builder
         var body: Body {


### PR DESCRIPTION
Support for heterogenous dictionaries (`[String: Any]`) was erroneously removed in a previous release. Adds this back.