### PR TITLE
Add support for visionOS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,23 @@ name: Build & Test
 on: [push]
 
 jobs:
+  
+  build-xcode:
+    strategy:
+      fail-fast: false
+      matrix:
+       os: [macos-14]
+       destination: ["iOS Simulator", "macOS", "tvOS Simulator", "watchOS Simulator", "visionOS Simulator"]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Select Xcode
+      run: sudo xcode-select -s /Applications/Xcode_15.2.app
+      
+    - name: Test
+      run: xcodebuild -scheme Relax-Package -destination 'platform= ${{ matrix.destination }}' test
+
   build:
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,9 @@ jobs:
     steps:
     - name: Select Xcode
       run: sudo xcode-select -s /Applications/Xcode_15.2.app
+
+    - name: Checkout
+      uses: actions/checkout@v4
       
     - name: Test
       run: xcodebuild -scheme Relax-Package -destination 'platform= ${{ matrix.destination }}' test


### PR DESCRIPTION
Confirm visionOS support through extending test matrix to all Apple platforms (iOS, macOS, watchOS, tvOS, visionOS) using xcodebuild. No source code changes needed.